### PR TITLE
Configure test data path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -95,7 +95,8 @@
         "regex": "cpp",
         "source_location": "cpp",
         "future": "cpp",
-        "typeindex": "cpp"
+        "typeindex": "cpp",
+        "*.in": "c"
     },
     "C_Cpp.errorSquiggles": "enabled"
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,15 +17,21 @@ set_target_properties(tests PROPERTIES
 
 include(CTest)
 include(Catch)
-catch_discover_tests(tests)
 
-if(AARE_TESTS)
-    set(TestSources
-            ${CMAKE_CURRENT_SOURCE_DIR}/test.cpp
-        )
-    target_sources(tests PRIVATE ${TestSources} )
+set(TestSources
+        ${CMAKE_CURRENT_SOURCE_DIR}/test.cpp
+    )
+target_sources(tests PRIVATE ${TestSources} )
 
-    #Work around to remove, this is not the way to do it =) 
-    # target_include_directories(tests PRIVATE ${CMAKE_SOURCE_DIR}/include/common)
-    target_link_libraries(tests PRIVATE core aare_compiler_flags)
-endif()
+#Work around to remove, this is not the way to do it =) 
+# target_include_directories(tests PRIVATE ${CMAKE_SOURCE_DIR}/include/common)
+target_link_libraries(tests PRIVATE core aare_compiler_flags)
+
+catch_discover_tests(tests
+    # WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/data
+)
+
+#configure a header to pass test file paths
+get_filename_component(TEST_FILE_PATH ${PROJECT_SOURCE_DIR}/data ABSOLUTE)
+configure_file(test_config.hpp.in test_config.hpp)
+target_include_directories(tests PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,1 +1,17 @@
-//Empty file to satisfy CMake when no other tests are added
+#include <catch2/catch_test_macros.hpp>
+#include <fstream>
+#include <filesystem>
+
+#include "test_config.hpp"
+
+
+TEST_CASE("Test suite can find data assets"){
+    auto fpath = test_data_path()/ "test_numpy_file.npy";
+    REQUIRE(std::filesystem::exists(fpath));
+}
+
+TEST_CASE("Test suite can open data assets"){
+    auto fpath = test_data_path()/ "test_numpy_file.npy";
+    auto f = std::ifstream(fpath, std::ios::binary);
+    REQUIRE(f.is_open());
+}

--- a/tests/test_config.hpp.in
+++ b/tests/test_config.hpp.in
@@ -1,0 +1,7 @@
+#pragma once
+#include <filesystem>
+
+static constexpr auto test_data_path_str = "@TEST_FILE_PATH@";
+inline auto test_data_path() {
+    return std::filesystem::path(test_data_path_str);
+}


### PR DESCRIPTION
Using CMake to configure the path to the included test data using a header. 