### PR TITLE
options for using the system libraries instead of fetch content

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,37 @@ option(AARE_PYTHON_BINDINGS "Build python bindings" ON)
 option(AARE_TESTS "Build tests" ON)
 option(AARE_EXAMPLES "Build examples" ON)
 
+option(AARE_FETCH_FMT "Use FetchContent to download fmt" ON)
+option(AARE_FETCH_PYBIND11 "Use FetchContent to download pybind11" ON)
+option(AARE_FETCH_CATCH "Use FetchContent to download catch2" ON)
+option(AARE_FETCH_JSON "Use FetchContent to download nlohmann::json" ON)
+
+#Convenience option to use system libraries
+option(AARE_SYSTEM_LIBRARIES "Use system libraries" OFF)
+if(AARE_SYSTEM_LIBRARIES)
+    message(STATUS "Build using system libraries")
+    set(AARE_FETCH_FMT OFF CACHE BOOL "Disabled FetchContent for FMT" FORCE)
+    set(AARE_FETCH_PYBIND11 OFF CACHE BOOL "Disabled FetchContent for pybind11" FORCE)
+    set(AARE_FETCH_CATCH OFF CACHE BOOL "Disabled FetchContent for catch2" FORCE)
+    set(AARE_FETCH_JSON OFF CACHE BOOL "Disabled FetchContent for nlohmann::json" FORCE)
+endif()
 
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-find_package(fmt 6 REQUIRED)
+
+if (AARE_FETCH_FMT)
+    set(FMT_TEST OFF CACHE INTERNAL "disabling fmt tests")
+    FetchContent_Declare(
+            fmt
+            GIT_REPOSITORY  https://github.com/fmtlib/fmt.git
+            GIT_TAG         10.2.1
+            GIT_PROGRESS    TRUE
+            USES_TERMINAL_DOWNLOAD TRUE
+    )
+    FetchContent_MakeAvailable(fmt)
+else()
+    find_package(fmt 6 REQUIRED)
+endif()
 
 add_library(aare_compiler_flags INTERFACE)
 target_compile_features(aare_compiler_flags INTERFACE cxx_std_17)
@@ -49,7 +76,7 @@ else()
         aare_compiler_flags
         INTERFACE
             -fdiagnostics-parseable-fixits
-            -fdiagnostics-generate-patch 
+            # -fdiagnostics-generate-patch 
             -fdiagnostics-show-template-tree 
             -fsanitize=address,undefined,pointer-compare 
             -fno-sanitize-recover 
@@ -62,7 +89,7 @@ else()
         aare_compiler_flags
         INTERFACE
             -fdiagnostics-parseable-fixits
-            -fdiagnostics-generate-patch 
+            # -fdiagnostics-generate-patch 
             -fdiagnostics-show-template-tree 
             -fsanitize=address,undefined,pointer-compare 
             -fno-sanitize-recover 

--- a/file_io/CMakeLists.txt
+++ b/file_io/CMakeLists.txt
@@ -1,8 +1,13 @@
-FetchContent_Declare(json
-    GIT_REPOSITORY https://github.com/nlohmann/json
-    GIT_TAG v3.11.3
-)
-FetchContent_MakeAvailable(json)
+
+if(AARE_FETCH_JSON)
+    FetchContent_Declare(json
+        GIT_REPOSITORY https://github.com/nlohmann/json
+        GIT_TAG v3.11.3
+    )
+    FetchContent_MakeAvailable(json)
+else()
+    find_package(nlohmann_json 3 REQUIRED)
+endif()
 
 set(SourceFiles
     ${CMAKE_CURRENT_SOURCE_DIR}/src/File.cpp

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,23 @@
 
 find_package (Python 3.11 COMPONENTS Interpreter Development)
-find_package(pybind11 2.11 REQUIRED)
+
+
+
+if(AARE_FETCH_PYBIND11)
+    FetchContent_Declare(
+        pybind11
+        GIT_REPOSITORY https://github.com/pybind/pybind11
+        GIT_TAG        v2.11.0
+    )
+    FetchContent_MakeAvailable(pybind11)
+else()
+    find_package(pybind11 2.11 REQUIRED)
+endif()
+
+
+
+
+
 pybind11_add_module(_aare src/bindings.cpp)
 set_target_properties(_aare PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,17 @@
-FetchContent_Declare(
-    Catch2
-    GIT_SHALLOW    TRUE
-    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG        v3.5.3
-)
-FetchContent_MakeAvailable(Catch2)
+
+if (AARE_FETCH_CATCH)
+    FetchContent_Declare(
+        Catch2
+        GIT_SHALLOW    TRUE
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG        v3.5.3
+    )
+    FetchContent_MakeAvailable(Catch2)
+else()
+    find_package(Catch2 3 REQUIRED)
+endif()
+
+
 list(APPEND CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras)
 
 add_executable(tests test.cpp)


### PR DESCRIPTION
Added options to use system libraries for:

- catch2
- json
- pybind11
- fmt

Default option is to get them using FetchContent but this can be disabled either per dependency 

```bash
cmake .. -DAARE_FETCH_JSON=OFF
```

or for all:
```bash
cmake .. -DAARE_SYSTEM_LIBRARIES=ON
```
