### PR TITLE
compiler generated constructors and reduced warnings

### DIFF
--- a/file_io/include/aare/File.hpp
+++ b/file_io/include/aare/File.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "aare/FileInterface.hpp"
 
 namespace aare{

--- a/file_io/include/aare/NumpyFile.hpp
+++ b/file_io/include/aare/NumpyFile.hpp
@@ -17,7 +17,7 @@ class NumpyFile : public FileInterface {
     uint32_t header_len{};
     uint8_t header_len_size{};
     ssize_t header_size{};
-    header_t m_header;
+    NumpyHeader m_header;
     uint8_t major_ver_{};
     uint8_t minor_ver_{};
 
@@ -29,7 +29,7 @@ class NumpyFile : public FileInterface {
     
 
     NumpyFile(const std::filesystem::path& fname);
-    NumpyFile(FileConfig, header_t);
+    NumpyFile(FileConfig, NumpyHeader);
     void write(Frame &frame) override;
     Frame read() override { return get_frame(this->current_frame++); }
 

--- a/file_io/include/aare/NumpyHelpers.hpp
+++ b/file_io/include/aare/NumpyHelpers.hpp
@@ -14,28 +14,20 @@
 #include "aare/DType.hpp"
 #include "aare/defs.hpp"
 
+namespace aare {
+
 using shape_t = std::vector<size_t>;
 
-struct header_t {
-    header_t() : dtype(aare::DType(aare::DType::ERROR)), fortran_order(false), shape(shape_t()){};
-    header_t(aare::DType dtype, bool fortran_order, shape_t shape)
-        : dtype(dtype), fortran_order(fortran_order), shape(shape){};
-    aare::DType dtype;
-    bool fortran_order;
-    shape_t shape;
-    std::string to_string() {
-        std::stringstream sstm;
-        sstm << "dtype: " << dtype.str() << ", fortran_order: " << fortran_order << ' ';
+struct NumpyHeader {
+    DType dtype{aare::DType::ERROR};
+    bool fortran_order{false};
+    shape_t shape{};    
 
-        sstm << "shape: (";
-        for (auto item : shape)
-            sstm << item << ',';
-        sstm << ')';
-        return sstm.str();
-    }
+    std::string to_string() const;
 };
 
-namespace aare::NumpyHelpers {
+namespace NumpyHelpers {
+
 const constexpr std::array<char, 6> magic_str{'\x93', 'N', 'U', 'M', 'P', 'Y'};
 const uint8_t magic_string_length{6};
 
@@ -59,8 +51,9 @@ template <typename T, size_t N> bool in_array(T val, const std::array<T, N> &arr
 bool is_digits(const std::string &str);
 
 aare::DType parse_descr(std::string typestring);
-size_t write_header(std::filesystem::path fname, const header_t &header) ;
-size_t write_header(std::ostream &out, const header_t &header) ;
-bool is_digits(const std::string &str);
+size_t write_header(std::filesystem::path fname, const NumpyHeader &header) ;
+size_t write_header(std::ostream &out, const NumpyHeader &header) ;
 
-} // namespace aare::NumpyHelpers
+
+} // namespace NumpyHelpers
+} // namespace aare

--- a/file_io/include/aare/RawFileFactory.hpp
+++ b/file_io/include/aare/RawFileFactory.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "aare/FileFactory.hpp"
 #include "aare/RawFile.hpp"
 

--- a/file_io/src/NumpyFile.cpp
+++ b/file_io/src/NumpyFile.cpp
@@ -12,7 +12,7 @@ NumpyFile::NumpyFile(const std::filesystem::path &fname) {
     }
     load_metadata();
 }
-NumpyFile::NumpyFile(FileConfig config, header_t header) {
+NumpyFile::NumpyFile(FileConfig config, NumpyHeader header) {
     mode = "w";
     m_fname = config.fname;
     m_bitdepth = config.dtype.bitdepth();

--- a/file_io/src/NumpyHelpers.cpp
+++ b/file_io/src/NumpyHelpers.cpp
@@ -24,18 +24,17 @@
 
 #include "aare/NumpyHelpers.hpp"
 
-namespace aare{
+namespace aare {
 
-std::string NumpyHeader::to_string() const{
-        std::stringstream sstm;
-        sstm << "dtype: " << dtype.str() << ", fortran_order: " << fortran_order << ' ';
-        sstm << "shape: (";
-        for (auto item : shape)
-            sstm << item << ',';
-        sstm << ')';
-        return sstm.str();
+std::string NumpyHeader::to_string() const {
+    std::stringstream sstm;
+    sstm << "dtype: " << dtype.str() << ", fortran_order: " << fortran_order << ' ';
+    sstm << "shape: (";
+    for (auto item : shape)
+        sstm << item << ',';
+    sstm << ')';
+    return sstm.str();
 }
-
 
 namespace NumpyHelpers {
 

--- a/file_io/src/NumpyHelpers.cpp
+++ b/file_io/src/NumpyHelpers.cpp
@@ -24,7 +24,20 @@
 
 #include "aare/NumpyHelpers.hpp"
 
-namespace aare::NumpyHelpers {
+namespace aare{
+
+std::string NumpyHeader::to_string() const{
+        std::stringstream sstm;
+        sstm << "dtype: " << dtype.str() << ", fortran_order: " << fortran_order << ' ';
+        sstm << "shape: (";
+        for (auto item : shape)
+            sstm << item << ',';
+        sstm << ')';
+        return sstm.str();
+}
+
+
+namespace NumpyHelpers {
 
 std::unordered_map<std::string, std::string> parse_dict(std::string in, const std::vector<std::string> &keys) {
     std::unordered_map<std::string, std::string> map;
@@ -209,12 +222,12 @@ inline std::string write_header_dict(const std::string &descr, bool fortran_orde
     return "{'descr': '" + descr + "', 'fortran_order': " + s_fortran_order + ", 'shape': " + shape_s + ", }";
 }
 
-size_t write_header(std::filesystem::path fname, const header_t &header) {
+size_t write_header(std::filesystem::path fname, const NumpyHeader &header) {
     std::ofstream out(fname, std::ios::binary | std::ios::out);
     return write_header(out, header);
 }
 
-size_t write_header(std::ostream &out, const header_t &header) {
+size_t write_header(std::ostream &out, const NumpyHeader &header) {
     std::string header_dict = write_header_dict(header.dtype.str(), header.fortran_order, header.shape);
 
     size_t length = magic_string_length + 2 + 2 + header_dict.length() + 1;
@@ -252,4 +265,5 @@ size_t write_header(std::ostream &out, const header_t &header) {
     return length;
 }
 
-} // namespace aare::NumpyHelpers
+} // namespace NumpyHelpers
+} // namespace aare


### PR DESCRIPTION
- renamed header_t to NumpyHeader 
- moved NumpyHeader into the aare:: namesapce
- removed constructors and let the compiler generate them
- removed shadow and redundant decl warnings