### PR TITLE
Minor fixes to build on Apple

### DIFF
--- a/src/core/include/aare/core/defs.hpp
+++ b/src/core/include/aare/core/defs.hpp
@@ -38,7 +38,7 @@ class Cluster {
             return;
         x = other.x;
         y = other.y;
-        mempcpy(m_data, other.m_data, other.size());
+        memcpy(m_data, other.m_data, other.size());
     }
     Cluster &operator=(const Cluster &other) {
         if (this == &other)

--- a/src/network_io/include/aare/network_io/ZmqHeader.hpp
+++ b/src/network_io/include/aare/network_io/ZmqHeader.hpp
@@ -36,7 +36,7 @@ namespace simdjson {
  * adds a check for 32bit overflow
  */
 template <> simdjson_inline simdjson::simdjson_result<uint32_t> simdjson::ondemand::value::get() noexcept {
-    size_t val = 0;
+    uint64_t val = 0;
     auto error = get_uint64().get(val);
     if (error) {
         return error;

--- a/src/network_io/include/aare/network_io/ZmqSocket.hpp
+++ b/src/network_io/include/aare/network_io/ZmqSocket.hpp
@@ -6,7 +6,7 @@
 // needs to be in sync with the main library (or maybe better use the versioning in the header)
 
 // forward declare zmq_msg_t to avoid including zmq.h in the header
-class zmq_msg_t;
+struct zmq_msg_t;
 
 namespace aare {
 

--- a/src/network_io/include/aare/network_io/ZmqSocketReceiver.hpp
+++ b/src/network_io/include/aare/network_io/ZmqSocketReceiver.hpp
@@ -9,7 +9,7 @@
 #include <string>
 
 // forward declare zmq_msg_t to avoid including zmq.h in the header
-class zmq_msg_t;
+struct zmq_msg_t;
 
 namespace aare {
 

--- a/src/processing/include/aare/processing/ClusterFinder.hpp
+++ b/src/processing/include/aare/processing/ClusterFinder.hpp
@@ -163,7 +163,7 @@ class ClusterFinder {
                 }
                 if (eventMask[iy][ix] == PHOTON and frame(iy, ix) - pedestal.mean(iy, ix) == max) {
                     eventMask[iy][ix] = PHOTON_MAX;
-                    Cluster cluster(m_cluster_sizeX, m_cluster_sizeY, typeid(FRAME_TYPE));
+                    Cluster cluster(m_cluster_sizeX, m_cluster_sizeY, DType(typeid(FRAME_TYPE)));
                     cluster.x = ix;
                     cluster.y = iy;
                     short i = 0;


### PR DESCRIPTION
Some small tweaks to make it build on Apple. 

Was there a specific reason to use mempcpy instead of memcpy in the Cluster class? 

