### PR TITLE
ClusterFileV2 minor cleanup

### DIFF
--- a/src/file_io/CMakeLists.txt
+++ b/src/file_io/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 
 if(AARE_TESTS)
     set(TestSources
+            ${CMAKE_CURRENT_SOURCE_DIR}/test/ClusterFileV2.test.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/test/NumpyFile.test.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/test/NumpyHelpers.test.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/test/RawFile.test.cpp

--- a/src/file_io/include/aare/file_io/ClusterFileV2.hpp
+++ b/src/file_io/include/aare/file_io/ClusterFileV2.hpp
@@ -47,16 +47,14 @@ class ClusterFileV2 {
     bool m_closed = true;
     std::filesystem::path m_fpath;
     std::string m_mode;
-    FILE *fp;
+    FILE *fp{nullptr};
 
   public:
-    ClusterFileV2(std::filesystem::path const &fpath, std::string const &mode) {
-        if (mode != "r" && mode != "w")
+    ClusterFileV2(std::filesystem::path const &fpath, std::string const &mode): m_fpath(fpath), m_mode(mode) {
+        if (m_mode != "r" && m_mode != "w")
             throw std::invalid_argument("mode must be 'r' or 'w'");
-        if (mode == "r" && !std::filesystem::exists(fpath))
+        if (m_mode == "r" && !std::filesystem::exists(m_fpath))
             throw std::invalid_argument("File does not exist");
-        m_fpath = fpath;
-        m_mode = mode;
         if (mode == "r") {
             fp = fopen(fpath.string().c_str(), "rb");
         } else if (mode == "w") {

--- a/src/file_io/include/aare/file_io/ClusterFileV2.hpp
+++ b/src/file_io/include/aare/file_io/ClusterFileV2.hpp
@@ -44,7 +44,6 @@ struct ClusterV2 {
  */
 class ClusterFileV2 {
   private:
-    bool m_closed = true;
     std::filesystem::path m_fpath;
     std::string m_mode;
     FILE *fp{nullptr};
@@ -67,7 +66,6 @@ class ClusterFileV2 {
         if (fp == nullptr) {
             throw std::runtime_error("Failed to open file");
         }
-        m_closed = false;
     }
     ~ClusterFileV2() { close(); }
     std::vector<ClusterV2> read() {
@@ -133,9 +131,9 @@ class ClusterFileV2 {
     }
 
     void close() {
-        if (!m_closed) {
+        if (fp) {
             fclose(fp);
-            m_closed = true;
+            fp = nullptr;
         }
     }
 };

--- a/src/file_io/test/ClusterFileV2.test.cpp
+++ b/src/file_io/test/ClusterFileV2.test.cpp
@@ -1,0 +1,27 @@
+#include "aare/file_io/ClusterFileV2.hpp"
+#include "aare/core/NDArray.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+#include "test_config.hpp"
+
+using aare::Dtype;
+using aare::ClusterFileV2;
+TEST_CASE("Reading a simple cluster file") {
+
+    auto fpath = test_data_path() / "clusters" / "single_frame_97_clustrers.clust";
+    REQUIRE(std::filesystem::exists(fpath));
+
+    ClusterFileV2 f(fpath, "r");
+    auto clusters = f.read(); // get the first frame
+    REQUIRE(clusters.size() == 97);
+
+}
+
+TEST_CASE("Throws when reading a closed file") {
+    auto fpath = test_data_path() / "clusters" / "single_frame_97_clustrers.clust";
+    REQUIRE(std::filesystem::exists(fpath));
+
+    ClusterFileV2 f(fpath, "r");
+    f.close();
+    REQUIRE_THROWS(f.read());
+}


### PR DESCRIPTION
- Using FILE* to keep track of state
- check FILE* before reading to avoid segfault if file is closed
- barebone tests