### PR TITLE
Modified moench05 transform

### DIFF
--- a/include/aare/PixelMap.hpp
+++ b/include/aare/PixelMap.hpp
@@ -7,6 +7,8 @@ namespace aare {
 
 NDArray<ssize_t, 2> GenerateMoench03PixelMap();
 NDArray<ssize_t, 2> GenerateMoench05PixelMap();
+NDArray<ssize_t, 2> GenerateMoench05PixelMap1g();
+NDArray<ssize_t, 2> GenerateMoench05PixelMapOld();
 
 //Matterhorn02
 NDArray<ssize_t, 2>GenerateMH02SingleCounterPixelMap();

--- a/python/aare/transform.py
+++ b/python/aare/transform.py
@@ -9,6 +9,24 @@ class Moench05Transform:
 
     def __call__(self, data):
         return np.take(data.view(np.uint16), self.pixel_map)
+    
+
+class Moench05Transform1g:
+    #Could be moved to C++ without changing the interface
+    def __init__(self):
+        self.pixel_map = _aare.GenerateMoench05PixelMap1g()
+
+    def __call__(self, data):
+        return np.take(data.view(np.uint16), self.pixel_map)
+    
+
+class Moench05TransformOld:
+    #Could be moved to C++ without changing the interface
+    def __init__(self):
+        self.pixel_map = _aare.GenerateMoench05PixelMapOld()
+
+    def __call__(self, data):
+        return np.take(data.view(np.uint16), self.pixel_map)
 
 
 class Matterhorn02Transform:
@@ -25,4 +43,6 @@ class Matterhorn02Transform:
 
 #on import generate the pixel maps to avoid doing it every time
 moench05 = Moench05Transform()
+moench05_1g = Moench05Transform1g()
+moench05_old = Moench05TransformOld()
 matterhorn02 = Matterhorn02Transform()

--- a/python/src/pixel_map.hpp
+++ b/python/src/pixel_map.hpp
@@ -21,6 +21,14 @@ void define_pixel_map_bindings(py::module &m) {
         auto ptr = new NDArray<ssize_t,2>(GenerateMoench05PixelMap());
         return return_image_data(ptr);
     })
+        .def("GenerateMoench05PixelMap1g", []() {
+        auto ptr = new NDArray<ssize_t,2>(GenerateMoench05PixelMap1g());
+        return return_image_data(ptr);
+    })
+    .def("GenerateMoench05PixelMapOld", []() {
+        auto ptr = new NDArray<ssize_t,2>(GenerateMoench05PixelMapOld());
+        return return_image_data(ptr);
+    })
     .def("GenerateMH02SingleCounterPixelMap", []() {
         auto ptr = new NDArray<ssize_t,2>(GenerateMH02SingleCounterPixelMap());
         return return_image_data(ptr);

--- a/src/PixelMap.cpp
+++ b/src/PixelMap.cpp
@@ -31,6 +31,49 @@ NDArray<ssize_t, 2> GenerateMoench03PixelMap() {
 }
 
 NDArray<ssize_t, 2> GenerateMoench05PixelMap() {
+    std::array<int, 3> adc_numbers = {5, 9, 1};  
+    NDArray<ssize_t, 2> order_map({160, 150});
+    int n_pixel = 0;
+    for (int row = 0; row < 160; row++) {
+        for (int i_col = 0; i_col < 50; i_col++) {
+            n_pixel = row * 50 + i_col;
+            for (int i_sc = 0; i_sc < 3; i_sc++) {
+                int col = 50 * i_sc + i_col;
+                int adc_nr = adc_numbers[i_sc];
+                int i_analog = n_pixel * 12 + adc_nr;  
+
+                // analog_frame[row * 150 + col] = analog_data[i_analog] & 0x3FFF;
+                order_map(row, col) = i_analog;
+                
+            }
+        }
+    }
+    return order_map;
+}
+
+NDArray<ssize_t, 2> GenerateMoench05PixelMap1g() {
+    std::array<int, 3> adc_numbers = {1, 2, 0}; 
+    NDArray<ssize_t, 2> order_map({160, 150});
+    int n_pixel = 0;
+    for (int row = 0; row < 160; row++) {
+        for (int i_col = 0; i_col < 50; i_col++) {
+            n_pixel = row * 50 + i_col;
+            for (int i_sc = 0; i_sc < 3; i_sc++) {
+                int col = 50 * i_sc + i_col;
+                int adc_nr = adc_numbers[i_sc];
+                int i_analog = n_pixel * 3 + adc_nr;  
+
+
+                // analog_frame[row * 150 + col] = analog_data[i_analog] & 0x3FFF;
+                order_map(row, col) = i_analog;
+                
+            }
+        }
+    }
+    return order_map;
+}
+
+NDArray<ssize_t, 2> GenerateMoench05PixelMapOld() {
     std::array<int, 3> adc_numbers = {9, 13, 1};
     NDArray<ssize_t, 2> order_map({160, 150});
     int n_pixel = 0;


### PR DESCRIPTION
Moench05 transforms: 
- moench05: Works with the updated firmware and better data compression (adcenable10g=0xFF0F)
- moench05_old: Works with the previous data and can be used with adcenable10g=0xFFFFFFFF
- moench05_1g: For the 1g data acquisition only with adcenable=0x2202