### PR TITLE
read_n returns remaining frames

### DIFF
--- a/src/CtbRawFile.cpp
+++ b/src/CtbRawFile.cpp
@@ -16,7 +16,7 @@ CtbRawFile::CtbRawFile(const std::filesystem::path &fname) : m_master(fname) {
 
 void CtbRawFile::read_into(std::byte *image_buf, DetectorHeader* header) {
     if(m_current_frame >= m_master.frames_in_file()){
-        throw std::runtime_error(LOCATION + "End of file reached");
+        throw std::runtime_error(LOCATION + " End of file reached");
     }
 
     if(m_current_frame != 0 && m_current_frame % m_master.max_frames_per_file() == 0){


### PR DESCRIPTION
Modified read_n to return the number of frames available if less than the number of frames requested. 

```python
#f is a CtbRawFile containing 10 frames

f.read_n(7) # you get 7 frames
f.read_n(7) # you get 3 frames
f.read_n(7) # RuntimeError
```

Also added support for chunk_size when iterating over a file:

```python
# The file contains 10 frames


with CtbRawFile(fname, chunk_size = 7) as f:
    for headers, frames in f:
        #do something with the data
        # 1 iteration 7 frames
        # 2 iteration 3 frames
        # 3 iteration stops
```