### PR TITLE
removed uneccecary codna numpy variants

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -3,11 +3,3 @@ python:
     - 3.12
     - 3.13
 
-numpy:
-    - 2.0
-    - 2.1
-    - 2.1
-
-zip_keys:
-    - python
-    - numpy

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,28 +1,13 @@
 python:
     - 3.11
-    - 3.11
-    - 3.11
-    - 3.12
-    - 3.12
     - 3.12
     - 3.13
 
-
-    
-numpy: 
-    - 1.26
-    - 2.0
-    - 2.1
-    - 1.26
+numpy:
     - 2.0
     - 2.1
     - 2.1
-
 
 zip_keys:
     - python
     - numpy
-
-pin_run_as_build:
-  numpy: x.x
-  python: x.x

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -2,55 +2,49 @@ package:
   name: aare
   version: 2025.4.22 #TODO! how to not duplicate this?
 
-
-
-
-
-
 source:
   path: ..
 
 build:
   number: 0
   script:
-    - unset CMAKE_GENERATOR && {{ PYTHON }} -m pip install . -vv  # [not win]
-    - {{ PYTHON }} -m pip install . -vv  # [win]
+    - unset CMAKE_GENERATOR && {{ PYTHON }} -m pip install . -vv 
 
 requirements:
   build:
-    - python {{python}}
-    - numpy {{ numpy }}
     - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+    - pip
+    - catch2
 
 
   host:
-    - cmake
-    - ninja
     - python {{python}}
-    - numpy {{ numpy }}
-    - pip
+    - numpy {{numpy}}
     - scikit-build-core
     - pybind11 >=2.13.0
     - fmt
     - zeromq
     - nlohmann_json
-    - catch2
+    - matplotlib # needed in host to solve the environment for run
 
   run:
     - python {{python}}
-    - numpy {{ numpy }}
+    - {{ pin_compatible('numpy') }}
     - matplotlib
+    
 
 
 test:
   imports:
     - aare
-  # requires:
-  #   - pytest
-  # source_files:
-  #   - tests
-  # commands:
-  #   - pytest tests
+  requires:
+    - pytest
+  source_files:
+    - python/tests
+  commands:
+    - python -m pytest python/tests
 
 about:
   summary: An example project built with pybind11 and scikit-build.

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,8 +15,6 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    - catch2
-
 
   host:
     - python

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -15,22 +15,19 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
-    - pip
     - catch2
 
 
   host:
-    - python {{python}}
-    - numpy {{numpy}}
+    - python
+    - pip
+    - numpy=2.1
     - scikit-build-core
     - pybind11 >=2.13.0
-    - fmt
-    - zeromq
-    - nlohmann_json
     - matplotlib # needed in host to solve the environment for run
 
   run:
-    - python {{python}}
+    - python
     - {{ pin_compatible('numpy') }}
     - matplotlib
     
@@ -47,5 +44,4 @@ test:
     - python -m pytest python/tests
 
 about:
-  summary: An example project built with pybind11 and scikit-build.
-  # license_file: LICENSE
+  summary: Data analysis library for hybrid pixel detectors from PSI 


### PR DESCRIPTION
With numpy 2.0 we no longer need to build against every supported numpy version. This way we can save up to 6 builds. 

- https://numpy.org/doc/stable/dev/depending_on_numpy.html
- https://conda-forge.org/docs/maintainer/knowledge_base/#building-against-numpy