### PR TITLE
droping version spec on sphinx

### DIFF
--- a/etc/dev-env.yml
+++ b/etc/dev-env.yml
@@ -11,4 +11,6 @@ dependencies:
   - furo 
   - zeromq 
   - pybind11
+  - numpy
+  - matplotlib
 


### PR DESCRIPTION
- Removing the version requirement on sphinx since the latest version works again
- added numpy and matplotlib do the etc/dev-env.yml since they are needed to import aare 