### PR TITLE
Fixed the order of cluster.data being incorrect

### DIFF
--- a/include/aare/ClusterFinder.hpp
+++ b/include/aare/ClusterFinder.hpp
@@ -144,9 +144,9 @@ class ClusterFinder {
                                     static_cast<CT>(
                                         m_pedestal.mean(iy + ir, ix + ic));
                                 cluster.data[i] =
-                                    tmp; // Watch for out of bounds access
-                                i++;
+                                    tmp; // Watch for out of bounds access                                
                             }
+                            i++;
                         }
                     }
 


### PR DESCRIPTION
While using the cluster finder and saving a cluster, pixels which are out of bounds are skipped. cluster.data should contain the pedestal corrected ADU information of each pixel. 

However, the counter "i" which keeps track of the position of cluster.data is only incremented if the pixel was inside the bounds of the frame. 

This means that any clusters close to the frame's edges are not construed properly. This means that if you want to extract a 3x3 from a 9x9 cluster, it can fail if the cluster data is not properly centered in the pixel.

Fixed by moving i++ outside the bounds check.