### PR TITLE
specified glibc in conda build

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -3,3 +3,14 @@ python:
     - 3.12
     - 3.13
 
+c_compiler:
+  - gcc                        # [linux]
+
+c_stdlib:
+  - sysroot                    # [linux]
+
+cxx_compiler:
+  - gxx                        # [linux]
+
+c_stdlib_version:              # [linux]
+  - 2.17                       # [linux]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,6 +16,8 @@ build:
 
 requirements:
   build:
+    - {{ compiler('c') }}
+    - {{ stdlib("c") }}
     - {{ compiler('cxx') }}
     - cmake
     - ninja


### PR DESCRIPTION
Fixed a runtime error on older linux systems, since by mistake we used glibc from ubutu 24. Same code as in slsDetectorPackage now. 