### PR TITLE
Added conda/pypi buyilds for python 3.14 removed 3.11

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@
     - Use ``read_roi/rois`` to read multiple ROIs for one frame, the index of a specific ROI to only read that ROI
     - Use ``read_n_with_roi`` to read multiple frames for a specific ROI. 
     - Note ``read_frame`` and ``read_n`` is not supported for multiple ROI's. 
+- Building conda/pypi pkgs for python 3.14. Removing 3.11 builds.
 
 ### Bugfixes: 
 

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 python:
-    - 3.11
     - 3.12
     - 3.13
+    - 3.14
 
 c_compiler:
   - gcc                        # [linux]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { file = "LICENSE" }
 
 [tool.cibuildwheel]
 
-build = "cp{311,312,313}-manylinux_x86_64"
+build = "cp{312,313,314}-manylinux_x86_64"
 
 
 


### PR DESCRIPTION
In line with supporting the 3 latest versions of Python