### PR TITLE
CI/CD: fix failing conda build command

### DIFF
--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Disable upload
         run: conda config --set anaconda_upload no
 
+      - name: Install conda-build in base
+        run: conda install -n base conda-build -y
+
       - name: Build
         run: conda build conda-recipe 
 

--- a/.github/workflows/build_conda.yml
+++ b/.github/workflows/build_conda.yml
@@ -25,10 +25,10 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: etc/dev-env.yml
@@ -36,13 +36,9 @@ jobs:
           channels: conda-forge
           conda-remove-defaults: "true"
 
-  
       - name: Disable upload
         run: conda config --set anaconda_upload no
 
-      - name: Install conda-build in base
-        run: conda install -n base conda-build -y
-
       - name: Build
-        run: conda build conda-recipe 
+        run: conda-build conda-recipe 
 

--- a/.github/workflows/build_conda_and_deploy_on_main.yml
+++ b/.github/workflows/build_conda_and_deploy_on_main.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Enable upload
         run: conda config --set anaconda_upload yes
 
+      - name: Install conda-build in base
+        run: conda install -n base conda-build -y
+
       - name: Build
         env:
           CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}

--- a/.github/workflows/build_conda_and_deploy_on_main.yml
+++ b/.github/workflows/build_conda_and_deploy_on_main.yml
@@ -21,10 +21,10 @@ jobs:
         shell: "bash -l {0}"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Get conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: etc/dev-env.yml
@@ -35,11 +35,8 @@ jobs:
       - name: Enable upload
         run: conda config --set anaconda_upload yes
 
-      - name: Install conda-build in base
-        run: conda install -n base conda-build -y
-
       - name: Build
         env:
           CONDA_TOKEN: ${{ secrets.CONDA_TOKEN }}
-        run: conda build conda-recipe --user slsdetectorgroup --token ${CONDA_TOKEN}
+        run: conda-build conda-recipe --user slsdetectorgroup --token ${CONDA_TOKEN}
 

--- a/etc/dev-env.yml
+++ b/etc/dev-env.yml
@@ -5,12 +5,12 @@ dependencies:
   - anaconda-client
   - catch2
   - conda-build
-  - doxygen 
+  - doxygen
   - sphinx
-  - breathe 
-  - sphinx_rtd_theme 
-  - furo 
-  - zeromq 
+  - breathe
+  - sphinx_rtd_theme
+  - furo
+  - zeromq
   - pybind11
   - numpy
   - matplotlib


### PR DESCRIPTION
Build conda pkgs workflows [failing](https://github.com/slsdetectorgroup/aare/actions/runs/25800676450/job/75789547058#step:5:10) due to the missing `conda build` command.

This PR fixes the issue.