### PR TITLE
Bugfix: NDArary/NDView overflow in calculating number of elements

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@
 ### Bugfixes:
 
 - Fixed ``split_task(first, last, n_threads)`` so task ranges now correctly respect the ``first`` offset. Previously, non-zero starting indices could generate incorrect subranges.
-
+- Fixed overflow issue causing failed allocations for NDArrays abouve ~2GB
 
 
 ## 2026.3.17

--- a/include/aare/NDView.hpp
+++ b/include/aare/NDView.hpp
@@ -48,7 +48,7 @@ Shape<Ndim - 1> drop_first_dim(const Shape<Ndim> &shape) {
  * @return The number of elements in and NDArray/NDView of that shape.
  */
 template <size_t Ndim> size_t num_elements(const Shape<Ndim> &shape) {
-    return std::accumulate(shape.begin(), shape.end(), 1,
+    return std::accumulate(shape.begin(), shape.end(), size_t{1},
                            std::multiplies<size_t>());
 }
 

--- a/src/NDView.test.cpp
+++ b/src/NDView.test.cpp
@@ -8,8 +8,8 @@
 #include <vector>
 
 using aare::NDView;
-using aare::Shape;
 using aare::num_elements;
+using aare::Shape;
 
 TEST_CASE("Calculate size from a shape") {
     Shape<3> shape{2, 3, 4};
@@ -24,7 +24,7 @@ TEST_CASE("Calculate size from a shape") {
     Shape<3> shape4{1000, 512, 1024};
     REQUIRE(num_elements(shape4) == 524288000);
 
-    //10GB which is more than INT_MAX bytes
+    // 10GB which is more than INT_MAX bytes
     Shape<3> shape5{10000, 1024, 1024};
     REQUIRE(num_elements(shape5) == 10485760000);
 }

--- a/src/NDView.test.cpp
+++ b/src/NDView.test.cpp
@@ -9,6 +9,25 @@
 
 using aare::NDView;
 using aare::Shape;
+using aare::num_elements;
+
+TEST_CASE("Calculate size from a shape") {
+    Shape<3> shape{2, 3, 4};
+    REQUIRE(num_elements(shape) == 24);
+
+    Shape<2> shape2{5, 5};
+    REQUIRE(num_elements(shape2) == 25);
+
+    Shape<1> shape3{10};
+    REQUIRE(num_elements(shape3) == 10);
+
+    Shape<3> shape4{1000, 512, 1024};
+    REQUIRE(num_elements(shape4) == 524288000);
+
+    //10GB which is more than INT_MAX bytes
+    Shape<3> shape5{10000, 1024, 1024};
+    REQUIRE(num_elements(shape5) == 10485760000);
+}
 
 TEST_CASE("Element reference 1D") {
     std::vector<int> vec;


### PR DESCRIPTION
Fixed number of elements calculation that caused integer overflow. Now return size_t instead of int. 