### PR TITLE
Fixed usage of fmt::format and fmt::print for C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,7 +260,7 @@ if(AARE_FETCH_FMT)
   FetchContent_MakeAvailable(fmt)
   set_property(TARGET fmt PROPERTY POSITION_INDEPENDENT_CODE ON)
 else()
-  find_package(fmt 6 REQUIRED)
+  find_package(fmt 8 REQUIRED)
 endif()
 
 if(AARE_FETCH_JSON)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@
 
 - Fixed ``split_task(first, last, n_threads)`` so task ranges now correctly respect the ``first`` offset. Previously, non-zero starting indices could generate incorrect subranges.
 - Fixed overflow issue causing failed allocations for NDArrays abouve ~2GB
+- Fixed libfmt failures due to consteval when building with C++20
 
 
 ## 2026.3.17

--- a/src/RawMasterFile.cpp
+++ b/src/RawMasterFile.cpp
@@ -50,8 +50,8 @@ std::filesystem::path RawFileNameComponents::data_fname(size_t mod_id,
     if (m_old_scheme) {
         fmt = "{}_d{}_f{:012}_{}.raw";
     }
-    return m_base_path /
-           fmt::format(fmt, m_base_name, mod_id, file_id, m_file_index);
+    return m_base_path / fmt::format(fmt::runtime(fmt), m_base_name, mod_id,
+                                     file_id, m_file_index);
 }
 
 void RawFileNameComponents::set_old_scheme(bool old_scheme) {

--- a/src/RawSubFile.cpp
+++ b/src/RawSubFile.cpp
@@ -167,7 +167,7 @@ void RawSubFile::parse_fname(const std::filesystem::path &fname) {
 }
 
 std::filesystem::path RawSubFile::fpath(size_t file_index) const {
-    auto fname = fmt::format(m_base_name, file_index);
+    auto fname = fmt::format(fmt::runtime(m_base_name), file_index);
     return m_path / fname;
 }
 

--- a/src/defs.cpp
+++ b/src/defs.cpp
@@ -7,7 +7,7 @@
 namespace aare {
 
 void assert_failed(const std::string &msg) {
-    fmt::print(msg);
+    fmt::print("{}", msg);
     exit(1);
 }
 


### PR DESCRIPTION
With C++20 `fmt::print(s)` expects a compile time format string and otherwise fails complaining about consteval. To get runtime formatting use `fmt::print(fmt::runtime(s))`

