### PR TITLE
Dev/matterhorn decoder

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,11 +10,13 @@
 - mask opeartor for ClusterVector ``masked_clustervector = aare.ClusterVector()(mask)``
 - passing pre computed eta values to ``aare.Interpolator.interpolate`` alongside clusters
 - Added ``PixelHistogram`` and ``PedestalTrackingPixelHistogram`` 
+- ``aare.transfrom.Matterhorn10Transform`` handles counter artefact in chip. Mind that enabling only one counter or three counters or enabling the wromg two counters e.g. 0,1 will still lead to erreneous data.
 
 ### Bugfixes:
 
 - Fixed ``split_task(first, last, n_threads)`` so task ranges now correctly respect the ``first`` offset. Previously, non-zero starting indices could generate incorrect subranges.
 - Fixed overflow issue causing failed allocations for NDArrays abouve ~2GB
+
 
 
 ## 2026.3.17

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,8 @@
 - mask opeartor for ClusterVector ``masked_clustervector = aare.ClusterVector()(mask)``
 - passing pre computed eta values to ``aare.Interpolator.interpolate`` alongside clusters
 - Added ``PixelHistogram`` and ``PedestalTrackingPixelHistogram`` 
-- ``aare.transfrom.Matterhorn10Transform`` handles counter artefact in chip. Mind that enabling only one counter or three counters or enabling the wromg two counters e.g. 0,1 will still lead to erreneous data.
+- ``aare.transfrom.Matterhorn10Transform`` handles counter artefact in chip. Mind that enabling only one counter or three counters or enabling the wromg two counters e.g. 0,1 will still lead to erreneous data. 
+- ``aare.transfrom.Matterhorn10Transform`` reshapes data such that first dimension is number of counters
 
 ### Bugfixes:
 

--- a/python/aare/transform.py
+++ b/python/aare/transform.py
@@ -81,6 +81,10 @@ class Matterhorn10Transform:
         A matterhorn chip has 256 columns and 256 rows.
         A matterhornchip with dynamic range 16 and 2 counters thus requires 
         256*256*16*2/(2*64) = 1024 transceiver samples. (Per default 2 channels are enabled per transceiver sample, each channel storing 64 bits)
+
+    .. note:: 
+        Due to an artefact in the chip, the transformation only fully supports 2 or 4 counters. Also if you enable 2 counters you can only select counter 1 and 2 or 0, 3 to get reasonable results. 
+        Otherwise only the first half of the image is correct. 
     """
     def __init__(self, dynamic_range : int, num_counters : int):
         self.pixel_map = _aare.GenerateMatterhorn10PixelMap(dynamic_range, num_counters)

--- a/python/aare/transform.py
+++ b/python/aare/transform.py
@@ -109,7 +109,7 @@ class Matterhorn10Transform:
         checks if data is compatible for transformation 
         
         :param data: data to be transformed, expected to be a 1D numpy array of uint8
-        :type data: np.ndarray
+        :type data: np.ndarray(n_counters, n_rows, n_cols) 
         :raises ValueError: if not compatible
         """
         expected_size = (Matterhorn10.nRows*Matterhorn10.nCols*self.num_counters*self.dynamic_range)//8 # read_frame returns data in uint8_t 
@@ -122,11 +122,11 @@ class Matterhorn10Transform:
     def __call__(self, data):
         self.data_compatibility(data)
         if self.dynamic_range == 16:
-            return np.take(data.view(np.uint16), self.pixel_map)
+            return np.take(data.view(np.uint16), self.pixel_map).reshape(self.num_counters, Matterhorn10.nRows, Matterhorn10.nCols)
         elif self.dynamic_range == 8: 
-            return np.take(data.view(np.uint8), self.pixel_map)
+            return np.take(data.view(np.uint8), self.pixel_map).reshape(self.num_counters, Matterhorn10.nRows, Matterhorn10.nCols)
         else: #dynamic range 4
-            return np.take(_aare.expand4to8bit(data.view(np.uint8)), self.pixel_map)
+            return np.take(_aare.expand4to8bit(data.view(np.uint8)), self.pixel_map).reshape(self.num_counters, Matterhorn10.nRows, Matterhorn10.nCols)
             
 class Mythen302Transform:
     """

--- a/python/tests/test_Transformation.py
+++ b/python/tests/test_Transformation.py
@@ -29,8 +29,6 @@ def test_matterhorn10_8bit(test_data_path):
 
         assert np.all(frames == expected_data)
 
-
-# TODO: update tests does no longer work with new pixel map 
 @pytest.mark.withdata
 def test_matterhorn10_4bit(test_data_path): 
     """ Matterhorn10Transform 1 counter 4 bit dynamic range """

--- a/python/tests/test_Transformation.py
+++ b/python/tests/test_Transformation.py
@@ -8,10 +8,10 @@ def test_matterhorn10_16bit(test_data_path):
     with CtbRawFile(test_data_path / "raw/Matterhorn10/16bit_master_0.json", transform = transform.Matterhorn10Transform(dynamic_range=16, num_counters=1)) as f:
         headers, frames = f.read_frame()
 
-        assert frames.shape == (256, 256)
+        assert frames.shape == (1, 256, 256)
         assert frames.dtype == np.uint16
 
-        expected_data = np.tile(np.arange(255, -1, -1,dtype=np.uint16), (256, 1)) # TODO: endianess issue ? 
+        expected_data = np.tile(np.arange(255, -1, -1,dtype=np.uint16), (1, 256, 1)) # TODO: endianess issue ? 
 
         assert np.all(frames == expected_data)
 
@@ -22,10 +22,10 @@ def test_matterhorn10_8bit(test_data_path):
     with CtbRawFile(test_data_path / "raw/Matterhorn10/8bit_master_1.json", transform = transform.Matterhorn10Transform(dynamic_range=8, num_counters=1)) as f:
         headers, frames = f.read_frame()
 
-        assert frames.shape == (256, 256)
+        assert frames.shape == (1, 256, 256)
         assert frames.dtype == np.uint8
 
-        expected_data = np.tile(np.arange(255, -1, -1,dtype=np.uint8), (256, 1)) # TODO: endianess issue ? 
+        expected_data = np.tile(np.arange(255, -1, -1,dtype=np.uint8), (1, 256, 1)) # TODO: endianess issue ? 
 
         assert np.all(frames == expected_data)
 
@@ -35,10 +35,10 @@ def test_matterhorn10_4bit(test_data_path):
     with CtbRawFile(test_data_path / "raw/Matterhorn10/newnewrun_4bit_1counter_master_0.json", transform = transform.Matterhorn10Transform(dynamic_range=4, num_counters=1)) as f:
         headers, frames = f.read_frame()
 
-        assert frames.shape == (256, 256)
+        assert frames.shape == (1, 256, 256)
         assert frames.dtype == np.uint8
 
-        expected_data = np.tile(np.tile(np.arange(15, -1, -1, dtype=np.uint8), 16), (256, 1)) # TODO: endianess issue ? 
+        expected_data = np.tile(np.tile(np.arange(15, -1, -1, dtype=np.uint8), 16), (1, 256, 1)) # TODO: endianess issue ? 
 
         assert np.all(frames == expected_data)
 
@@ -49,9 +49,9 @@ def test_matterhorn10_16bit_4counters(test_data_path):
     with CtbRawFile(test_data_path / "raw/Matterhorn10/4counter_16bit_master_4.json", transform = transform.Matterhorn10Transform(dynamic_range=16, num_counters=4)) as f:
         headers, frames = f.read_frame()
 
-        assert frames.shape == (4*256, 256)
+        assert frames.shape == (4, 256, 256)
         assert frames.dtype == np.uint16
 
-        expected_data = np.tile(np.arange(255, -1, -1,dtype=np.uint16), (4*256, 1)) # TODO: endianess issue ? 
+        expected_data = np.tile(np.arange(255, -1, -1,dtype=np.uint16), (4, 256, 1)) # TODO: endianess issue ? 
 
         assert np.all(frames == expected_data)

--- a/python/tests/test_Transformation.py
+++ b/python/tests/test_Transformation.py
@@ -30,6 +30,7 @@ def test_matterhorn10_8bit(test_data_path):
         assert np.all(frames == expected_data)
 
 
+# TODO: update tests does no longer work with new pixel map 
 @pytest.mark.withdata
 def test_matterhorn10_4bit(test_data_path): 
     """ Matterhorn10Transform 1 counter 4 bit dynamic range """

--- a/src/PixelMap.cpp
+++ b/src/PixelMap.cpp
@@ -200,17 +200,11 @@ NDArray<ssize_t, 2> GenerateMatterhorn10PixelMap(const size_t dynamic_range,
     const size_t num_consecutive_pixels_in_package =
         packet_size / num_consecutive_pixels;
 
-    // TODO: couls mask pixel map to -1 if actual_counter does not exist (not
-    // knwon which counters have been set. 0,1, 2,3), later mask after getting
-    // the pixel map
     for (size_t row = 0; row < n_rows; ++row) {
         for (size_t counter = 0; counter < n_counters; ++counter) {
             size_t col = 0;
             size_t actual_counter =
-                row < half_rows
-                    ? counter
-                    : (3 - counter); // TODO: right now will throw an error when
-                                     // using np.take (out of bounds)
+                row < half_rows ? counter : (n_counters - counter - 1);
             for (size_t package = 0; package < num_64_bit_packages; ++package) {
                 for (size_t consecutive_pixel_group = 0;
                      consecutive_pixel_group <

--- a/src/PixelMap.cpp
+++ b/src/PixelMap.cpp
@@ -195,12 +195,22 @@ NDArray<ssize_t, 2> GenerateMatterhorn10PixelMap(const size_t dynamic_range,
 
     constexpr size_t num_64_bit_packages = 4; // n_cols/64
 
+    constexpr size_t half_rows = n_rows / 2; // 128
+
     const size_t num_consecutive_pixels_in_package =
         packet_size / num_consecutive_pixels;
 
+    // TODO: couls mask pixel map to -1 if actual_counter does not exist (not
+    // knwon which counters have been set. 0,1, 2,3), later mask after getting
+    // the pixel map
     for (size_t row = 0; row < n_rows; ++row) {
         for (size_t counter = 0; counter < n_counters; ++counter) {
             size_t col = 0;
+            size_t actual_counter =
+                row < half_rows
+                    ? counter
+                    : (3 - counter); // TODO: right now will throw an error when
+                                     // using np.take (out of bounds)
             for (size_t package = 0; package < num_64_bit_packages; ++package) {
                 for (size_t consecutive_pixel_group = 0;
                      consecutive_pixel_group <
@@ -213,7 +223,7 @@ NDArray<ssize_t, 2> GenerateMatterhorn10PixelMap(const size_t dynamic_range,
                             consecutive_pixel_group * num_64_bit_packages *
                                 num_consecutive_pixels +
                             pixel + row * n_cols * n_counters +
-                            n_cols * counter;
+                            n_cols * actual_counter;
                         ++col;
                     }
                 }


### PR DESCRIPTION
- reshape image directly in decoder such that first dimension is num counters 
- take into account chip artefact in decoder. 