### PR TITLE
cmake: treat warnings as errors

### DIFF
--- a/.gitea/workflows/cmake_build.yml
+++ b/.gitea/workflows/cmake_build.yml
@@ -47,7 +47,7 @@ jobs:
             source venv/bin/activate
             mkdir build 
             cd build 
-            cmake .. -DAARE_PYTHON_BINDINGS=ON -DAARE_DOCS=ON 
+            cmake .. -DAARE_PYTHON_BINDINGS=ON -DAARE_DOCS=ON -DAARE_WARNINGS_AS_ERRORS=ON
             make -j 2 
             make docs
 

--- a/.github/workflows/build_with_docs.yml
+++ b/.github/workflows/build_with_docs.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
             mkdir build 
             cd build 
-            cmake .. -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAARE_SYSTEM_LIBRARIES=ON -DAARE_PYTHON_BINDINGS=ON -DAARE_DOCS=ON -DAARE_TESTS=ON
+            cmake .. -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DAARE_SYSTEM_LIBRARIES=ON -DAARE_PYTHON_BINDINGS=ON -DAARE_DOCS=ON -DAARE_TESTS=ON -DAARE_WARNINGS_AS_ERRORS=ON
             make -j 4 
             make docs
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ option(AARE_FETCH_ZMQ "Use FetchContent to download libzmq" ON)
 option(AARE_FETCH_LMFIT "Use FetchContent to download lmfit" ON)
 option(AARE_FETCH_MINUIT2 "Use FetchContent to download Minuit2" ON)
 
+option(AARE_WARNINGS_AS_ERRORS "Treat warnings as errors during compilation"
+       OFF)
+
 # Convenience option to use system libraries only (no FetchContent)
 option(AARE_SYSTEM_LIBRARIES "Use system libraries" OFF)
 if(AARE_SYSTEM_LIBRARIES)
@@ -348,6 +351,10 @@ else()
               -Werror=return-type # important can cause segfault in optimzed
                                   # builds
   )
+
+  if(AARE_WARNINGS_AS_ERRORS)
+    target_compile_options(aare_compiler_flags INTERFACE -Werror)
+  endif()
 
 endif() # GCC/Clang specific
 

--- a/src/hist/PedestalTrackingPixelHistogram.cpp
+++ b/src/hist/PedestalTrackingPixelHistogram.cpp
@@ -58,7 +58,7 @@ PedestalTrackingPixelHistogram::PedestalTrackingPixelHistogram(
     partial_std_.reserve(n_threads_);
     for (int i = 0; i < n_threads_; ++i) {
         const auto local_rows = row_count(i);
-        partial_hists_.emplace_back(local_rows, cols, n_bins, xmin, xmax);
+        partial_hists_.emplace_back(local_rows, cols, n_bins, xmin_, xmax_);
         partial_pedestals_.emplace_back(static_cast<uint32_t>(local_rows),
                                         static_cast<uint32_t>(cols));
         partial_std_.emplace_back(NDArray<AxisType, 2>(

--- a/src/hist/PixelHistogram.test.cpp
+++ b/src/hist/PixelHistogram.test.cpp
@@ -60,14 +60,14 @@ TEST_CASE("Fill one pixel of a 5x10 histogram") {
 }
 
 TEST_CASE("Fill pixels with uneven partial histogram row slices") {
-    PixelHistogram hist(5, 4, 10, 0.0, 10.0, 3);
-    NDArray<float, 2> image({5, 4}, -1.0);
+    PixelHistogram hist(5, 4, 10, 0.0f, 10.0f, 3);
+    NDArray<float, 2> image({5, 4}, -1.0f);
 
-    image(0, 0) = 0.2;
-    image(1, 1) = 1.2;
-    image(2, 2) = 2.2;
-    image(3, 3) = 3.2;
-    image(4, 0) = 4.2;
+    image(0, 0) = 0.2f;
+    image(1, 1) = 1.2f;
+    image(2, 2) = 2.2f;
+    image(3, 3) = 3.2f;
+    image(4, 0) = 4.2f;
 
     hist.fill_async(NDArray<float, 2>(image));
     hist.flush();

--- a/src/hist/PixelHistogram.test.cpp
+++ b/src/hist/PixelHistogram.test.cpp
@@ -1,6 +1,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
+#include "aare/logger.hpp"
 #include <chrono>
 #include <cstdint>
 #include <random>
@@ -25,14 +26,15 @@ namespace {
 } // namespace
 
 TEST_CASE("Fill one pixel of a 5x10 histogram") {
-    PixelHistogram hist(5, 10, 20, 0.0, 10.0);
+    PixelHistogram hist(5, 10, 20, 0.0f, 10.0f);
     NDArray<float, 2> image(
-        {5, 10}, -1.0); // Need to fill with -1 to not generate counts
+        {5, 10}, -1.0f); // Need to fill with -1 to not generate counts
 
-    image(2, 3) = 5.7; // This should go into bin 11 (since bins are [0-0.5),
-                       // [0.5-1.0), ..., [9.5-10.0))
+    image(2, 3) = 5.7f; // This should go into bin 11 (since bins are [0-0.5),
+                        // [0.5-1.0), ..., [9.5-10.0))
 
     // fill_blocking(hist, image.view());
+
     hist.fill_async(NDArray<float, 2>(image));
     hist.flush(); // Wait for the async fill to complete before we check the
                   // results

--- a/src/hist/PixelHistogram.test.cpp
+++ b/src/hist/PixelHistogram.test.cpp
@@ -230,7 +230,7 @@ TEST_CASE("Random fills match a reference implementation") {
 }
 
 TEST_CASE("fill_async with mismatched shape throws") {
-    PixelHistogram hist(8, 8, 16, 0.0, 1.0, 2);
+    PixelHistogram hist(8, 8, 16, 0.0f, 1.0f, 2);
     NDArray<float, 2> bad({4, 4}, 0.0f);
     CHECK_THROWS_AS(hist.fill_async(std::move(bad)), std::invalid_argument);
 }


### PR DESCRIPTION
- treating warnings as errors during github and gitea workflows 